### PR TITLE
chore: cleanup

### DIFF
--- a/src/common/durakGamesStore.ts
+++ b/src/common/durakGamesStore.ts
@@ -2,11 +2,4 @@ import DurakGamesStore from "../DurakGamesStore.js";
 
 export const durakGamesStore = new DurakGamesStore();
 
-declare global {
-  // eslint-disable-next-line no-var
-  var durakGamesStore: DurakGamesStore;
-}
-
-globalThis.durakGamesStore = durakGamesStore;
-
 export default durakGamesStore;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,3 @@
 export { default as raise } from "./raise.js";
 export { durakGamesStore } from "./durakGamesStore.js";
-export { stringToArray, stringToBoolean } from "./zod.js";
+export { stringToArray } from "./zod.js";

--- a/src/common/raise.ts
+++ b/src/common/raise.ts
@@ -1,3 +1,5 @@
-export default function raise(err: Error | string = new Error()): never {
-  throw typeof err === "string" ? new Error(err) : err;
-}
+import assert from "node:assert";
+
+const raise = assert.fail;
+
+export default raise;

--- a/src/common/zod.ts
+++ b/src/common/zod.ts
@@ -1,13 +1,3 @@
-import raise from "./raise.js";
-
-export function stringToBoolean(str: string) {
-  return str === "true"
-    ? true
-    : str === "false"
-      ? false
-      : raise('value must be "true" or "false"');
-}
-
 export function stringToArray(str: string) {
   return str.split(",").map((value) => value.trim());
 }

--- a/src/module/Chat/createMessage.ts
+++ b/src/module/Chat/createMessage.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { ChatMessage, ChatReplyMessage } from "./entity/index.js";
 import type { ChatContext } from "../../plugins/modules/chat/global-chat.auto-load.js";
 

--- a/src/plugins/modules/login/login.auto-load.ts
+++ b/src/plugins/modules/login/login.auto-load.ts
@@ -6,27 +6,33 @@ import assert from "node:assert";
 import { prisma } from "../../../config/index.js";
 import { stringToBoolean } from "../../../common/index.js";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { isDevelopment } from "std-env";
 
 const plugin: FastifyPluginAsyncZod = async function (fastify) {
+  let redirectUrl = process.env.AUTH_REDIRECT_URL;
+  if (!redirectUrl) {
+    const defaultRedirectUrl = isDevelopment
+      ? "http://localhost:5173"
+      : "https://play-durak.vercel.app";
+    fastify.log.warn(
+      "AUTH_REDIRECT_URL not found in environment, using %s",
+      defaultRedirectUrl,
+    );
+    redirectUrl = defaultRedirectUrl;
+  }
   fastify.route({
     method: "POST",
     url: "/api/auth/login",
     schema: {
       querystring: z.object({
         anonymous: z.string().transform(stringToBoolean),
-        dev: z.string().transform(stringToBoolean),
       }),
     },
     async handler(request, reply) {
-      console.log({ anon: request.query.anonymous });
       if (typeof request.session.user?.isAnonymous === "undefined") {
         await mutateSessionWithAnonymousUser(request, this.log);
       }
-      return reply.redirect(
-        request.query.dev
-          ? "http://localhost:5173"
-          : "https://play-durak.vercel.app",
-      );
+      return reply.redirect(redirectUrl);
     },
   });
 };

--- a/src/plugins/modules/login/login.auto-load.ts
+++ b/src/plugins/modules/login/login.auto-load.ts
@@ -4,7 +4,6 @@ import crypto from "node:crypto";
 import assert from "node:assert";
 
 import { prisma } from "../../../config/index.js";
-import { stringToBoolean } from "../../../common/index.js";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { isDevelopment } from "std-env";
 
@@ -25,7 +24,7 @@ const plugin: FastifyPluginAsyncZod = async function (fastify) {
     url: "/api/auth/login",
     schema: {
       querystring: z.object({
-        anonymous: z.string().transform(stringToBoolean),
+        anonymous: z.coerce.boolean().default(true),
       }),
     },
     async handler(request, reply) {

--- a/src/plugins/modules/login/login.auto-load.ts
+++ b/src/plugins/modules/login/login.auto-load.ts
@@ -22,11 +22,6 @@ const plugin: FastifyPluginAsyncZod = async function (fastify) {
   fastify.route({
     method: "POST",
     url: "/api/auth/login",
-    schema: {
-      querystring: z.object({
-        anonymous: z.coerce.boolean().default(true),
-      }),
-    },
     async handler(request, reply) {
       if (typeof request.session.user?.isAnonymous === "undefined") {
         await mutateSessionWithAnonymousUser(request, this.log);

--- a/src/plugins/modules/user-profile/user-profile.auto-load.ts
+++ b/src/plugins/modules/user-profile/user-profile.auto-load.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import assert from "assert";
+import assert from "node:assert";
 import { prisma } from "../../../config/index.js";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
     /* Language and Environment */
     "target": "ES2022",
     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ES2023", "ES2023.Array", "ESNext.Array", "ESNext"],
+    "lib": [
+      "ES2023",
+      "ES2023.Array",
+      "ESNext.Array",
+      "ESNext"
+    ],
     /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -108,5 +113,5 @@
     "skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
     "skipLibCheck": true
     /* Skip type checking all .d.ts files. */
-  }
+  },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */


### PR DESCRIPTION
- Fix production build
- Update login API
- Make `raise` as alias to `assert.fail`
- Remove `stringToBoolean` in common
- Remove `globalThis` mutation
- Prepend `node` in import paths