### PR TITLE
refactor(plugins): cleanup

### DIFF
--- a/src/plugins/core.auto-load.ts
+++ b/src/plugins/core.auto-load.ts
@@ -5,9 +5,8 @@ import { fastifySession } from "@fastify/session";
 import { fastifyWebsocket } from "@fastify/websocket";
 import { getFastifySessionSettings } from "../config/fastify.js";
 import { env, sessionStore } from "../config/index.js";
-import type { FastifyInstance } from "fastify";
 
-export default async function myPlugin(app: FastifyInstance) {
+export default <FastifyPluginAsyncZod>async function myPlugin(app) {
   await app
     .register(fastifyCors, {
       origin: env.CORS_ORIGIN,
@@ -18,4 +17,4 @@ export default async function myPlugin(app: FastifyInstance) {
     .register(fastifyCookie)
     .register(fastifySession, getFastifySessionSettings(env, sessionStore))
     .register(fastifyWebsocket);
-}
+};

--- a/src/plugins/core.auto-load.ts
+++ b/src/plugins/core.auto-load.ts
@@ -6,7 +6,7 @@ import { fastifyWebsocket } from "@fastify/websocket";
 import { getFastifySessionSettings } from "../config/fastify.js";
 import { env, sessionStore } from "../config/index.js";
 
-export default <FastifyPluginAsyncZod>async function myPlugin(app) {
+export default <FastifyPluginAsyncZod>async function (app) {
   await app
     .register(fastifyCors, {
       origin: env.CORS_ORIGIN,

--- a/src/plugins/modules/chat/global-chat.auto-load.ts
+++ b/src/plugins/modules/chat/global-chat.auto-load.ts
@@ -1,31 +1,33 @@
-import { type FastifyInstance } from "fastify";
 import {
   CustomWebsocketEvent,
   NotificationAlertEvent,
 } from "../../../ws/index.js";
 import createMessage from "../../../module/Chat/createMessage.js";
-import type { Chat, ChatMessage, ChatReplyMessage } from "../../../module/Chat/entity/index.js";
+import type {
+  Chat,
+  ChatMessage,
+  ChatReplyMessage,
+} from "../../../module/Chat/entity/index.js";
 import initializeChat from "../../../module/Chat/initializeChatNamespace.js";
 
 export type ChatContext = ReturnType<ReturnType<typeof initializeChat>>;
 
 export const autoConfig = { path: "/global-chat" };
 
-export default async function(
-  fastify: FastifyInstance,
-  options: { path: string },
-) {
-  const getChatContext = initializeChat();
-  return fastify.get(
-    options.path,
-    { websocket: true },
-    async function (socket, request) {
-      const context = getChatContext(socket, request);
-      socket.send(new ChatRestoreEvent(context.chat).asString);
-      socket.on("message::send", onMessageSendListener.bind(context));
-    },
-  );
-}
+export default <FastifyPluginAsyncZod<{ path: string }>>(
+  async function (app, options) {
+    const getChatContext = initializeChat();
+    app.get(
+      options.path,
+      { websocket: true },
+      async function (socket, request) {
+        const context = getChatContext(socket, request);
+        socket.send(new ChatRestoreEvent(context.chat).asString);
+        socket.on("message::send", onMessageSendListener.bind(context));
+      },
+    );
+  }
+);
 
 async function onMessageSendListener(
   this: ChatContext,

--- a/src/plugins/modules/game-lobbies.ts/game-lobbies.auto-load.ts
+++ b/src/plugins/modules/game-lobbies.ts/game-lobbies.auto-load.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import type { WebSocket } from "@fastify/websocket";
-import type { FastifyInstance, FastifyRequest } from "fastify";
+import type { FastifyRequest } from "fastify";
 import type { InitialGameSettings } from "@durak-game/durak-dts";
 import {
   CustomWebsocketEvent,
@@ -12,12 +12,12 @@ import {
 import Lobbies from "../../../module/Lobbies/entity/Lobbies.js";
 import type Lobby from "../../../module/Lobbies/entity/Lobby.js";
 
-export default async function gameLobbiesPlugin(fastify: FastifyInstance) {
+export default <FastifyPluginAsyncZod>async function (app) {
   const handleConnection = initializeGameLobbies();
-  fastify.get(
+  app.get(
     "/game-lobbies",
     { websocket: true },
-    async function (socket: WebSocket, request: FastifyRequest) {
+    async function (socket, request) {
       const context = handleConnection(socket, request);
       if (!context.user?.id) {
         socket.send(
@@ -85,7 +85,7 @@ export default async function gameLobbiesPlugin(fastify: FastifyInstance) {
       }
     },
   );
-}
+};
 
 function initializeGameLobbies() {
   const socketsStore = new SocketsStore();

--- a/src/plugins/modules/login/login.auto-load.ts
+++ b/src/plugins/modules/login/login.auto-load.ts
@@ -1,28 +1,27 @@
 import { isDevelopment } from "std-env";
-import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import {
   createAnonymousUser,
   mutateSessionWithAnonymousUser,
 } from "./login.instance-decorators.js";
 
-export default <FastifyPluginAsyncZod>async function (fastify) {
+export default <FastifyPluginAsyncZod>async function (app) {
   let redirectUrl = process.env.AUTH_REDIRECT_URL;
   if (!redirectUrl) {
     const defaultRedirectUrl = isDevelopment
       ? "http://localhost:5173"
       : "https://play-durak.vercel.app";
-    fastify.log.warn(
+    app.log.warn(
       "AUTH_REDIRECT_URL not found in environment, using %s",
       defaultRedirectUrl,
     );
     redirectUrl = defaultRedirectUrl;
   }
-  fastify.decorate(
+  app.decorate(
     "mutateSessionWithAnonymousUser",
     mutateSessionWithAnonymousUser,
   );
-  fastify.decorate("createAnonymousUser", createAnonymousUser);
-  fastify.route({
+  app.decorate("createAnonymousUser", createAnonymousUser);
+  app.route({
     method: "POST",
     url: "/api/auth/login",
     async handler(request, reply) {

--- a/src/plugins/modules/login/me.auto-load.ts
+++ b/src/plugins/modules/login/me.auto-load.ts
@@ -1,5 +1,3 @@
-import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-
 export default <FastifyPluginAsyncZod>async function (app) {
   app.route({
     method: "GET",

--- a/src/plugins/modules/user-profile/user-profile.auto-load.ts
+++ b/src/plugins/modules/user-profile/user-profile.auto-load.ts
@@ -1,9 +1,8 @@
 import z from "zod";
 import assert from "node:assert";
-import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 
-const plugin: FastifyPluginAsyncZod = async function (fastify) {
-  fastify.route({
+export default <FastifyPluginAsyncZod>async function (app) {
+  app.route({
     method: "GET",
     url: "/api/profiles/:personalLink",
     schema: {
@@ -28,5 +27,3 @@ const plugin: FastifyPluginAsyncZod = async function (fastify) {
     },
   });
 };
-
-export default plugin;

--- a/src/plugins/socket-io.auto-load.ts
+++ b/src/plugins/socket-io.auto-load.ts
@@ -15,6 +15,6 @@ export default <FastifyPluginAsyncZod>async function (app) {
     .ready()
     .then(() => {
       assert("io" in app);
-      createSocketIoServer(app.io as unknown as SocketIO.Server, sessionStore);
+      createSocketIoServer(<SocketIO.Server>app.io, sessionStore);
     });
 };

--- a/src/plugins/socket-io.auto-load.ts
+++ b/src/plugins/socket-io.auto-load.ts
@@ -1,10 +1,9 @@
 import assert from "node:assert";
 import fastifySocketIO from "fastify-socket.io";
-import type { FastifyInstance } from "fastify";
 import type SocketIO from "socket.io";
 import { createSocketIoServer, env, sessionStore } from "../config/index.js";
 
-export default function (app: FastifyInstance) {
+export default <FastifyPluginAsyncZod>async function (app) {
   app
     .register(fastifySocketIO.default, {
       cors: {
@@ -18,4 +17,4 @@ export default function (app: FastifyInstance) {
       assert("io" in app);
       createSocketIoServer(app.io as unknown as SocketIO.Server, sessionStore);
     });
-}
+};

--- a/src/plugins/validator.auto-load.ts
+++ b/src/plugins/validator.auto-load.ts
@@ -1,11 +1,7 @@
-import type { FastifyInstance } from "fastify";
-import {
-  serializerCompiler,
-  validatorCompiler,
-} from "fastify-type-provider-zod";
+import fastifyTypeProviderZod from "fastify-type-provider-zod";
 
-export default function (app: FastifyInstance) {
+export default <FastifyPluginAsyncZod>async function (app) {
   app
-    .setValidatorCompiler(validatorCompiler)
-    .setSerializerCompiler(serializerCompiler);
-}
+    .setValidatorCompiler(fastifyTypeProviderZod.validatorCompiler)
+    .setSerializerCompiler(fastifyTypeProviderZod.serializerCompiler);
+};


### PR DESCRIPTION
- Rename `Fastify` instances to app
- Remove names in default exports
- Use only `FastifyPluginAsyncZod`